### PR TITLE
Source files history is missing. Mandatory reference to original proj…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # OpenPLC Editor
 OpenPLC Editor - IDE capable of creating programs for the OpenPLC Runtime.
 
+OpenPLC Editor repository contains modified versions of [Beremiz](https://github.com/beremiz/beremiz) (GPLv2 and LGPLv2) and [MatIEC](https://github.com/beremiz/matiec) (GPLv3) projects.
+
 The codebase has been updated to Python3 and wxPython Phoenix.
 
 Runs on: Windows, Linux, macOS


### PR DESCRIPTION
This change is clearly stating origins of most of the source code in that repository, so that developers know where to find file history and know where to commit changes.

BTW, Beremiz is GPLv2. How can you re-license it as  GPLv3 ?